### PR TITLE
Simplify release workflows and release prep script

### DIFF
--- a/.github/workflows/nuget-push-public.yml
+++ b/.github/workflows/nuget-push-public.yml
@@ -1,7 +1,8 @@
 name: NuGet Push Public
 
-on: 
-  workflow_call:
+on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -13,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,7 @@ name: Release
 
 on:
   workflow_call:
-    inputs:
-      draft:
-        description: "Draft mode: 'auto' (Patch=release, Minor/Major=draft), 'true', or 'false'"
-        type: string
-        default: 'auto'
-    outputs:
-      bump_level:
-        value: ${{ jobs.build-test-prep-release.outputs.bump_level }}
-      drafted:
-        value: ${{ jobs.build-test-prep-release.outputs.drafted }}
   workflow_dispatch:
-    inputs:
-      draft:
-        description: "Draft mode: 'auto' (Patch=release, Minor/Major=draft), 'true', or 'false'"
-        type: choice
-        options: ['auto', 'true', 'false']
-        default: 'auto'
 
 permissions:
   contents: write
@@ -26,9 +10,6 @@ permissions:
 jobs:
   build-test-prep-release:
     runs-on: ubuntu-latest
-    outputs:
-      bump_level: ${{ steps.prepare.outputs.bump_level }}
-      drafted: ${{ steps.release.outputs.drafted }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
         with:
@@ -56,25 +37,11 @@ jobs:
           git push origin HEAD
           git push origin ${{ steps.prepare.outputs.new_version }}
       - name: create github release
-        id: release
         if: steps.prepare.outputs.bump_level != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          DRAFT_INPUT="${{ inputs.draft }}"
-          BUMP_LEVEL="${{ steps.prepare.outputs.bump_level }}"
-
-          DRAFT_FLAG="--draft"
-          if [ "$DRAFT_INPUT" = "false" ]; then
-            DRAFT_FLAG=""
-          elif [ "$DRAFT_INPUT" = "auto" ] && [ "$BUMP_LEVEL" = "Patch" ]; then
-            DRAFT_FLAG=""
-          fi
-
           gh release create ${{ steps.prepare.outputs.new_version }} \
             --title "${{ steps.prepare.outputs.new_version }}" \
             --notes-file "${{ steps.prepare.outputs.release_notes_file }}" \
-            $DRAFT_FLAG
-
-          echo "drafted=$( [ -n "$DRAFT_FLAG" ] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
-
+            --draft

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -53,15 +53,4 @@ jobs:
     needs: update-dependencies
     if: needs.update-dependencies.outputs.has_changes == 'true'
     uses: ./.github/workflows/release.yml
-    with:
-      draft: 'auto'
-    secrets: inherit
-
-  publish-nuget:
-    needs: release
-    if: needs.release.outputs.bump_level != '' && needs.release.outputs.drafted == 'false'
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/nuget-push-public.yml
     secrets: inherit

--- a/prepare-release.cs
+++ b/prepare-release.cs
@@ -12,10 +12,8 @@
 //    4. Calculate the version bump: MAJOR / MINOR / PATCH / none
 //    5. Build formatted release notes and prepend them to CHANGELOG.md
 //    6. Update <Version> in src/Directory.Build.props
-//    7. Update <span class="_version"> elements in README.md and docs/*.md
-//    8. Update <!--_release-notes--> blocks in docs/*.md (full release notes)
-//    9. Update <!--_release-notes--> block in README.md (release notes without section heading)
-//   10. Prepend release notes to docs/History.md
+//    7. Update <span class="_version"> elements in README.md
+//    8. Update <!--_release-notes--> block in README.md (release notes without section heading)
 //
 // Conventional Commits and version bump rules:
 //   MAJOR bump  - any commit with `!` after the type, e.g. `feat!:` or `fix(scope)!:`
@@ -42,7 +40,7 @@ string repoRoot = Directory.GetCurrentDirectory();
 if (!Directory.Exists(Path.Combine(repoRoot, ".git")))
     throw new InvalidOperationException("No .git directory found. Run this script from the repository root.");
 
-Console.WriteLine("Finbuckle.MultiTenant - Release Preparation");
+Console.WriteLine("Finbuckle.Html5Validation - Release Preparation");
 Console.WriteLine();
 
 // --- Step 1: Find the latest semantic-version tag ---
@@ -94,10 +92,10 @@ PrependToChangelog(releaseNotes, repoRoot);
 // --- Step 7: Update <Version> in src/Directory.Build.props ---
 UpdateBuildPropsVersion(newVersion, repoRoot);
 
-// --- Step 8: Update _version spans in README.md and docs/*.md ---
+// --- Step 8: Update _version spans in README.md ---
 UpdateVersionSpans(newVersion, repoRoot);
 
-// --- Step 9 & 10: Update <!--_release-notes--> blocks ---
+// --- Step 9: Update <!--_release-notes--> block ---
 UpdateReleaseNotesBlocks(releaseNotes, repoRoot);
 
 Console.WriteLine();
@@ -155,7 +153,7 @@ static string Git(string args)
 
 // Resolve the GitHub HTTPS base URL from the git remote named "origin".
 // Handles both SSH (git@github.com:Owner/Repo.git) and HTTPS remote formats.
-// Falls back to the Finbuckle repo URL if the remote cannot be read.
+// Falls back to this repository URL if the remote cannot be read.
 static string GetRepoUrl()
 {
     try
@@ -169,7 +167,7 @@ static string GetRepoUrl()
     }
     catch
     {
-        return "https://github.com/Finbuckle/Finbuckle.MultiTenant";
+        return "https://github.com/Finbuckle/Finbuckle.Html5Validation";
     }
 }
 
@@ -573,39 +571,32 @@ static void UpdateBuildPropsVersion(SemanticVersion newVersion, string repoRoot)
 }
 
 // STEP 8 - Replace <span class="_version">…</span> elements with the new
-// version string in README.md and every docs/*.md file.
+// version string in README.md.
 static void UpdateVersionSpans(SemanticVersion newVersion, string repoRoot)
 {
     Console.WriteLine("Step 8: Update _version spans");
     Console.WriteLine();
 
-    var files = new List<string>();
     string readme = Path.Combine(repoRoot, "README.md");
-    if (File.Exists(readme)) files.Add(readme);
-
-    string docsDir = Path.Combine(repoRoot, "docs");
-    if (Directory.Exists(docsDir))
-        files.AddRange(Directory.GetFiles(docsDir, "*.md"));
-
-    foreach (var file in files)
+    if (File.Exists(readme))
     {
-        string content = File.ReadAllText(file);
+        string content = File.ReadAllText(readme);
         string updated = Regex.Replace(
             content,
             @"<span class=""_version"">.*?</span>",
             $"""<span class="_version">{newVersion}</span>""");
 
 
-        File.WriteAllText(file, updated);
-        Console.WriteLine($"{file} updated.");
+        File.WriteAllText(readme, updated);
+        Console.WriteLine($"{readme} updated.");
     }
 }
 
-// STEP 9 & 10 - Replace <!--_release-notes-->…<!--_release-notes--> delimiters
-// in docs/*.md (full release notes) and README.md (notes without the first heading line).
+// STEP 9 - Replace <!--_release-notes-->…<!--_release-notes--> delimiters
+// in README.md with release notes without the first heading line.
 static void UpdateReleaseNotesBlocks(string releaseNotes, string repoRoot)
 {
-    Console.WriteLine("Step 9 & 10: Update <!--_release-notes--> blocks");
+    Console.WriteLine("Step 9: Update <!--_release-notes--> block");
     Console.WriteLine();
 
     // For README, strip the first line (the "## [version](url) (date)" heading)
@@ -615,24 +606,6 @@ static void UpdateReleaseNotesBlocks(string releaseNotes, string repoRoot)
     // Regex that matches the content between the marker comments (dotall / singleline)
     const string markerPattern = @"<!--_release-notes-->.*?<!--_release-notes-->";
     const RegexOptions dotAll  = RegexOptions.Singleline;
-
-    string docsDir = Path.Combine(repoRoot, "docs");
-    if (Directory.Exists(docsDir))
-    {
-        foreach (var file in Directory.GetFiles(docsDir, "*.md"))
-        {
-            string content = File.ReadAllText(file);
-            if (!Regex.IsMatch(content, markerPattern, dotAll)) continue;
-
-            string updated = Regex.Replace(
-                content,
-                markerPattern,
-                $"<!--_release-notes-->\n{releaseNotes}\n<!--_release-notes-->",
-                dotAll);
-            File.WriteAllText(file, updated);
-            Console.WriteLine($"{file} updated.");
-        }
-    }
 
     string readme = Path.Combine(repoRoot, "README.md");
     if (File.Exists(readme))


### PR DESCRIPTION
This streamlines the release pipeline so drafting and publishing are clearly separated, and removes release-script behavior that is not used by this repository.

## What changed
- `release.yml` now always creates **draft** GitHub releases and drops draft-mode inputs/outputs.
- `nuget-push-public.yml` now runs on `release.published`, so NuGet publishing happens after a release is actually published.
- `update-dotnet-dependencies.yml` no longer chains directly into NuGet publish; it only triggers the release workflow.
- `prepare-release.cs` was simplified to this repo's needs:
  - project name and fallback repo URL now target `Finbuckle.Html5Validation`
  - README-only version span updates
  - README-only `<!--_release-notes-->` block updates
  - removed obsolete docs/History-oriented step text and logic

## Notes for reviewers
This keeps release creation safely draft-only while making publish-to-NuGet event-driven from release publication, so manual publish of a draft release now drives package publication consistently.